### PR TITLE
fastlane: improve full description and add DE locale

### DIFF
--- a/metadata/de/full_description.txt
+++ b/metadata/de/full_description.txt
@@ -1,0 +1,15 @@
+Es ist wichtig, Ihr Android-Gerät zu sperren, wenn Sie es nicht benutzen, damit niemand sonst auf Ihre Apps und Daten zugreifen kann.
+
+Ihr Fingerabdruck - Ihre Sicherheit. Es ist praktisch, aber nicht völlig sicher. Wir haben daran gearbeitet, ein Gleichgewicht zwischen Bequemlichkeit und Sicherheit zu schaffen.
+
+Die Funktion „Bildschirmzeitüberschreitung“ von Android schaltet den Bildschirm Ihres Geräts aus und sperrt ihn nach einer bestimmten Zeitspanne.
+
+Die Funktion „Schütteln und Sperren“ schützt Sie sofort in jeder unerwarteten Situation.
+
+<b>Features:</b>
+
+* <i>Quick Tile Settings</i>. Quick Settings sind Kacheln, die im Quick Settings-Panel angezeigt werden und Aktionen repräsentieren, auf die der Benutzer tippen kann, um sofortige Sperren auszuführen.
+* <i>Shortcuts</i>. Hilft, allgemeine oder empfohlene Aufgaben innerhalb Ihrer Anwendung schnell zu starten.
+* <i>Modern UI</i>. Genießen Sie eine visuell ansprechende und moderne Benutzeroberfläche, die den Grundsätzen des Material You-Designs folgt.
+* <i>Funktioniert offline und respektiert die Privatsphäre</i>. Paranoid's Pal funktioniert unabhängig, ohne dass eine Internetverbindung oder eine Online-Kontoregistrierung erforderlich ist. Ihre vertraulichen Daten bleiben immer auf Ihrem Gerät. Weder die Entwickler noch Dritte können auf Ihre Informationen zugreifen.
+* <i>Angepasst für Android 12</i> SplashScreen, Edge-to-Edge, Predictive Back Navigation, Verbesserung der modernen Android UI Erfahrung.

--- a/metadata/de/short_description.txt
+++ b/metadata/de/short_description.txt
@@ -1,0 +1,1 @@
+Schützen Sie Ihre digitale Identität

--- a/metadata/en-US/full_description.txt
+++ b/metadata/en-US/full_description.txt
@@ -1,14 +1,14 @@
- These days, maintaining privacy on our devices has become increasingly challenging. With so much of our personal information stored on our phones, it’s essential to ensure it stays protected, whether from accidental access or malicious intent. Imagine situations where someone unlocks your phone while you're unaware or a scammer forces access. These scenarios are all too real in today's world.
+These days, maintaining privacy on our devices has become increasingly challenging. With so much of our personal information stored on our phones, it’s essential to ensure it stays protected, whether from accidental access or malicious intent. Imagine situations where someone unlocks your phone while you're unaware or a scammer forces access. These scenarios are all too real in today's world.
 
 That’s why I developed <i>Paranoid's Pal - Privacy Lock</i> It’s designed to offer an extra layer of security on top of Android’s built-in features. Here’s what makes Paranoid's Pal stand out:
 
-    * Instant Lock with Shake: In urgent situations, just shake your phone, and it locks immediately, ensuring quick protection when you need it.
-    * Automatic Screen Lock: Your phone locks automatically once the screen turns off, ensuring it's secure even when you're not actively using it.
+* Instant Lock with Shake: In urgent situations, just shake your phone, and it locks immediately, ensuring quick protection when you need it.
+* Automatic Screen Lock: Your phone locks automatically once the screen turns off, ensuring it's secure even when you're not actively using it.
 
 <b>Features:</b>
 
-* <i>Quick Tile Settings</i>. Quick Settings are tiles displayed in the Quick Settings panel, representing actions, that users can tap to quickly complete instant lock. 
+* <i>Quick Tile Settings</i>. Quick Settings are tiles displayed in the Quick Settings panel, representing actions, that users can tap to quickly complete instant lock.
 * <i>Shortcuts</i>. Helps your quickly start common or recommended tasks within your app.
 * <i>Modern UI</i>. Enjoy a visually appealing and modern interface, following the principles of the Material You design.
-* <i>Works offline and respects your privacy</i>. Paranoid's Pal operates independently without needing an internet connection or online account registration. Your confidential data always remains on your device. Neither the developers nor any third parties can access your information. 
-* <i>Adopted for Android 12</i> SplashScreen, Edge to Edge, Predictive Back navigation, enhancing modern Android UI experience. 
+* <i>Works offline and respects your privacy</i>. Paranoid's Pal operates independently without needing an internet connection or online account registration. Your confidential data always remains on your device. Neither the developers nor any third parties can access your information.
+* <i>Adopted for Android 12</i> SplashScreen, Edge to Edge, Predictive Back navigation, enhancing modern Android UI experience.


### PR DESCRIPTION
This PR slightly improves formatting of the English full description, making it possible to render it as Markdown (supported e.g. at IzzyOnDroid) while keeping it compatible with places not supporting it (e.g. F-Droid.org, PlayStore). It also adds the German (de) locale with short and full description.